### PR TITLE
fix(portal): improve logic for moving target, support older browsers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2550,7 +2550,7 @@
 			"dependencies": {
 				"async": {
 					"version": "0.9.2",
-					"resolved": "http://registry.npmjs.org/async/-/async-0.9.2.tgz",
+					"resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
 					"integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
 					"dev": true
 				},
@@ -4415,13 +4415,13 @@
 			}
 		},
 		"@marko/testing-library": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@marko/testing-library/-/testing-library-1.1.2.tgz",
-			"integrity": "sha512-I2bzIpW5aZTiMrq6spHin8S1m1+mCJNjROBVelEBotSinWYWqaM1NLuzeZrHogL/XAuqcXaiv9BKU+K6n2Ek4g==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@marko/testing-library/-/testing-library-3.0.0.tgz",
+			"integrity": "sha512-8Wzl4GfVoyfyoM6fxQkXO04a27MrDAIPW5VhXruVTfm+JAUmj9Md1R2X0bIPFlHEvmMOugyL1jeoIJx34T8Q7w==",
 			"dev": true,
 			"requires": {
-				"@testing-library/dom": "^5.4.0",
-				"jsdom": "^15.1.1",
+				"@testing-library/dom": "^6.8.1",
+				"jsdom": "^15.2.0",
 				"tslib": "^1.10.0"
 			}
 		},
@@ -4664,16 +4664,17 @@
 			}
 		},
 		"@testing-library/dom": {
-			"version": "5.6.1",
-			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-5.6.1.tgz",
-			"integrity": "sha512-Y1T2bjtvQMewffn1CJ28kpgnuvPYKsBcZMagEH0ppfEMZPDc8AkkEnTk4smrGZKw0cblNB3lhM2FMnpfLExlHg==",
+			"version": "6.11.0",
+			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-6.11.0.tgz",
+			"integrity": "sha512-Pkx9LMIGshyNbfmecjt18rrAp/ayMqGH674jYER0SXj0iG9xZc+zWRjk2Pg9JgPBDvwI//xGrI/oOQkAi4YEew==",
 			"dev": true,
 			"requires": {
-				"@babel/runtime": "^7.5.5",
+				"@babel/runtime": "^7.6.2",
 				"@sheerun/mutationobserver-shim": "^0.3.2",
+				"@types/testing-library__dom": "^6.0.0",
 				"aria-query": "3.0.0",
-				"pretty-format": "^24.8.0",
-				"wait-for-expect": "^1.2.0"
+				"pretty-format": "^24.9.0",
+				"wait-for-expect": "^3.0.0"
 			}
 		},
 		"@types/anymatch": {
@@ -4840,6 +4841,15 @@
 			"integrity": "sha512-78AdXtlhpCHT0K3EytMpn4JNxaf5tbqbLcbIRoQIHzpTIyjpxLQKRoxU55ujBXAtg3Nl2h/XWvfDa9dsMOd0pQ==",
 			"dev": true
 		},
+		"@types/testing-library__dom": {
+			"version": "6.11.0",
+			"resolved": "https://registry.npmjs.org/@types/testing-library__dom/-/testing-library__dom-6.11.0.tgz",
+			"integrity": "sha512-qUmnGl6H0wajUaO3VCJJoAeN/bQwpUzCqE/hk96NiGjIh5H4b8LfmQTOj4cHfS/9hCwO0DJytC6osHYDYiouyA==",
+			"dev": true,
+			"requires": {
+				"pretty-format": "^24.3.0"
+			}
+		},
 		"@types/uglify-js": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.0.4.tgz",
@@ -4875,9 +4885,9 @@
 			}
 		},
 		"@types/yargs": {
-			"version": "13.0.3",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.3.tgz",
-			"integrity": "sha512-K8/LfZq2duW33XW/tFwEAfnZlqIfVsoyRB3kfXdPXYhl0nfM8mmh7GS0jg7WrX2Dgq/0Ha/pR1PaR+BvmWwjiQ==",
+			"version": "13.0.4",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.4.tgz",
+			"integrity": "sha512-Ke1WmBbIkVM8bpvsNEcGgQM70XcEh/nbpxQhW7FhrsbCsXSY9BmLB1+LHtD7r9zrsOcFlLiF+a/UeJsdfw3C5A==",
 			"dev": true,
 			"requires": {
 				"@types/yargs-parser": "*"
@@ -5928,9 +5938,9 @@
 			},
 			"dependencies": {
 				"acorn": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
-					"integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==",
+					"version": "6.4.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.0.tgz",
+					"integrity": "sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw==",
 					"dev": true
 				}
 			}
@@ -11574,7 +11584,7 @@
 		},
 		"es6-promisify": {
 			"version": "5.0.0",
-			"resolved": "http://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
 			"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
 			"dev": true,
 			"requires": {
@@ -18357,7 +18367,7 @@
 				},
 				"find-up": {
 					"version": "3.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
 					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
 					"dev": true,
 					"requires": {
@@ -18372,7 +18382,7 @@
 				},
 				"is-fullwidth-code-point": {
 					"version": "2.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
 					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
 					"dev": true
 				},
@@ -18393,7 +18403,7 @@
 				},
 				"locate-path": {
 					"version": "3.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
 					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
 					"dev": true,
 					"requires": {
@@ -18430,7 +18440,7 @@
 				},
 				"p-locate": {
 					"version": "3.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
 					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
 					"dev": true,
 					"requires": {
@@ -18457,7 +18467,7 @@
 				},
 				"resolve-from": {
 					"version": "4.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
 					"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
 					"dev": true
 				},
@@ -19044,13 +19054,13 @@
 			"dependencies": {
 				"get-stream": {
 					"version": "3.0.0",
-					"resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
 					"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
 					"dev": true
 				},
 				"got": {
 					"version": "6.7.1",
-					"resolved": "http://registry.npmjs.org/got/-/got-6.7.1.tgz",
+					"resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
 					"integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
 					"dev": true,
 					"requires": {
@@ -23230,7 +23240,7 @@
 				},
 				"get-stream": {
 					"version": "3.0.0",
-					"resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
 					"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
 					"dev": true
 				},
@@ -24151,9 +24161,9 @@
 			}
 		},
 		"wait-for-expect": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/wait-for-expect/-/wait-for-expect-1.3.0.tgz",
-			"integrity": "sha512-8fJU7jiA96HfGPt+P/UilelSAZfhMBJ52YhKzlmZQvKEZU2EcD1GQ0yqGB6liLdHjYtYAoGVigYwdxr5rktvzA==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/wait-for-expect/-/wait-for-expect-3.0.1.tgz",
+			"integrity": "sha512-3Ha7lu+zshEG/CeHdcpmQsZnnZpPj/UsG3DuKO8FskjuDbkx3jE3845H+CuwZjA2YWYDfKMU2KhnCaXMLd3wVw==",
 			"dev": true
 		},
 		"warp10": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "@commitlint/cli": "^8.2.0",
     "@commitlint/config-conventional": "^8.2.0",
     "@commitlint/config-lerna-scopes": "^8.2.0",
-    "@marko/testing-library": "^1.1.2",
+    "@marko/testing-library": "^3.0.0",
     "chai": "^4.2.0",
     "chai-dom": "^1.8.1",
     "cheerio": "^1.0.0-rc.3",

--- a/tags/portal/index.marko
+++ b/tags/portal/index.marko
@@ -9,12 +9,12 @@ class {
             .getComponent();
     }
     onInput(newInput) {
-        let component = this.component;
+        var component = this.component;
         if (component) {
-            let target = this.getTarget(newInput.target);
+            var target = this.getTarget(newInput.target);
 
             if (target !== this.target) {
-                component.els.forEach(el => target.appendChild(el));
+                component.appendTo(target);
                 this.target = target;
             }
 
@@ -32,6 +32,4 @@ class {
     }
 }
 
-<span style={
-    display: "none"
-}/>
+<!--  -->

--- a/tags/portal/target.marko
+++ b/tags/portal/target.marko
@@ -1,1 +1,1 @@
-<include(input.renderBody)/>
+<${input}/>

--- a/tags/portal/test/test.browser.js
+++ b/tags/portal/test/test.browser.js
@@ -1,0 +1,62 @@
+const { render, cleanup } = require("@marko/testing-library");
+const { expect, use } = require("chai");
+use(require("sinon-chai"));
+const template = require("../");
+
+describe("browser", () => {
+  const targetA = document.createElement("div");
+  const targetB = document.createElement("div");
+  let rerender;
+
+  targetA.id = "a";
+  targetB.id = "b";
+
+  before(() => {
+    document.body.appendChild(targetA);
+    document.body.appendChild(targetB);
+  });
+
+  after(() => {
+    document.body.removeChild(targetA);
+    document.body.removeChild(targetB);
+  });
+
+  beforeEach(async () => {
+    ({ rerender } = await render(template, {
+      renderBody(out) {
+        out.text("A");
+      },
+      target: targetA.id
+    }));
+  });
+
+  afterEach(() => {
+    cleanup();
+    targetA.innerHTML = targetB.innerHTML = "";
+  });
+
+  it("should have rendered the initial content", () => {
+    expect(targetA).has.text("A");
+  });
+
+  it("can update the content", async () => {
+    await rerender({
+      renderBody(out) {
+        out.text("B");
+      },
+      target: targetA.id
+    });
+    expect(targetA).has.text("B");
+  });
+
+  it("can change the target", async () => {
+    await rerender({
+      renderBody(out) {
+        out.text("A");
+      },
+      target: targetB.id
+    });
+    expect(targetA).has.text("");
+    expect(targetB).has.text("A");
+  });
+});

--- a/tags/portal/test/test.server.js
+++ b/tags/portal/test/test.server.js
@@ -1,0 +1,17 @@
+const assert = require("assert");
+const sinon = require("sinon");
+const { render } = require("@marko/testing-library");
+const template = require("../");
+
+describe("server", () => {
+  it("does not render anything", async () => {
+    const renderBodySpy = sinon.spy();
+    const { container } = await render(template, {
+      renderBody: renderBodySpy,
+      target: "somewhere"
+    });
+
+    assert.ok(renderBodySpy.notCalled);
+    assert.strictEqual(container.childElementCount, 0);
+  });
+});


### PR DESCRIPTION
## Scope

`<portal>`

## Description

Updates the portal tag to avoid using features not supported in older browsers.
Fixes issue with top level text being moved to a new target within a portal and an issue where removing the portal would cause an error.

This PR also adds tests for the portal tag.

- [x] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
