### PR TITLE
fix(match-media): update tag def to avoid deprecated default

### DIFF
--- a/tags/match-media/index.marko
+++ b/tags/match-media/index.marko
@@ -1,6 +1,6 @@
 class {
   onCreate(input) {
-    var queries = input["*"];
+    var queries = input.queries;
     this.matches = Object.keys(queries).reduce(function(matches, name) {
       matches[name] = false;
       return matches;
@@ -15,10 +15,10 @@ class {
     var matchers = (this.matchers = this.matchers || {});
     var prevInput = this.prevInput;
     var input = (this.prevInput = this.input);
-    var queries = input["*"];
+    var queries = input.queries;
 
     if (prevInput) {
-      var prevQueries = prevInput["*"];
+      var prevQueries = prevInput.queries;
       Object.keys(prevQueries).forEach(function(name) {
         if (queries[name] === prevQueries[name]) return;
         if (!(name in queries)) delete matches[name];

--- a/tags/match-media/marko.json
+++ b/tags/match-media/marko.json
@@ -1,6 +1,9 @@
 {
   "<match-media>": {
     "template": "./index.marko",
-    "@*": "expression"
+    "@*": {
+      "type": "expression",
+      "targetProperty": "queries"
+    }
   }
 }

--- a/tags/match-media/test/test.browser.js
+++ b/tags/match-media/test/test.browser.js
@@ -24,7 +24,7 @@ describe("browser", () => {
     await waitFrames(frame.contentWindow, 10);
     const renderResult = await render(template, {
       renderBody: renderBodySpy,
-      "*": {
+      queries: {
         mobile: "(max-width: 767px)",
         tablet: "(min-width: 768px) and (max-width: 1024px)",
         desktop: "(min-width: 1025px)"
@@ -72,7 +72,7 @@ describe("browser", () => {
   it("can change media queries", async () => {
     await rerender({
       renderBody: renderBodySpy,
-      "*": {
+      queries: {
         landscape: "(orientation: landscape)",
         portrait: "(orientation: portrait)"
       }

--- a/tags/match-media/test/test.server.js
+++ b/tags/match-media/test/test.server.js
@@ -8,7 +8,7 @@ describe("server", () => {
     const renderBodySpy = sinon.spy();
     await render(template, {
       renderBody: renderBodySpy,
-      "*": {
+      queries: {
         mobile: "(max-width: 767px)",
         tablet: "(min-width: 768px) and (max-width: 1024px)",
         desktop: "(min-width: 1025px)"


### PR DESCRIPTION
## Scope
`<match-media>`

## Description
Using `@*` in a tag definition without `targetProperty` is now deprecated since the default value is changing. This PR updates the `match-media` tag to not rely on the deprecated feature.

## Checklist:

- [x] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
