### PR TITLE
feat(context): use constructor instance as context id

### DIFF
--- a/tags/context/package.json
+++ b/tags/context/package.json
@@ -17,9 +17,6 @@
   "peerDependencies": {
     "marko": "^4.15.0"
   },
-  "dependencies": {
-    "lasso-modules-client": "^2.0.5"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/marko-js/tags"

--- a/tags/context/src/components/context/transformer.js
+++ b/tags/context/src/components/context/transformer.js
@@ -1,5 +1,3 @@
-const lassoClientTransport = require("lasso-modules-client/transport");
-
 module.exports = function(el, ctx) {
   const { builder } = ctx;
 
@@ -10,12 +8,12 @@ module.exports = function(el, ctx) {
 
     if (from) {
       if (from === ".") {
-        from = lassoClientTransport.getClientPath(ctx.filename);
+        from = buildModuleExports(builder);
       } else {
         const fromTag = ctx.taglibLookup.getTag(from);
 
         if (fromTag) {
-          from = lassoClientTransport.getClientPath(fromTag.template);
+          from = ctx.importTemplate(fromTag.template);
         } else {
           return ctx.addError(
             `context receiver could not find context provider matching 'from="${from}"'.`
@@ -30,15 +28,21 @@ module.exports = function(el, ctx) {
 
     const getNode = ctx.createNodeForEl("get-context");
     getNode.params = el.params;
-    getNode.setAttributeValue("__from", builder.literal(from));
+    getNode.setAttributeValue("__from", from);
     getNode.body = el.body;
     el.replaceWith(getNode);
   } else {
     // Set context tag.
-    const from = lassoClientTransport.getClientPath(ctx.filename);
     setNode = ctx.createNodeForEl("set-context", el.getAttributes());
-    setNode.setAttributeValue("__from", builder.literal(from));
+    setNode.setAttributeValue("__from", buildModuleExports(builder));
     setNode.body = el.body;
     el.replaceWith(setNode);
   }
 };
+
+function buildModuleExports(builder) {
+  return builder.memberExpression(
+    builder.identifier("module"),
+    builder.identifier("exports")
+  );
+}

--- a/tags/context/src/components/get-context/index.marko
+++ b/tags/context/src/components/get-context/index.marko
@@ -6,15 +6,14 @@ static const noop = function() {};
 
 class {
   onInput(input, out) {
-    var to = this.id;
-    var name = input.__from;
-    var provider = getProvider(out, name);
+    var type = input.__from;
+    var provider = getProvider(out, type);
 
     if (provider) {
       this.state = provider.data;
       this.emitToProvider = provider.emit && provider.emit.bind(provider);
 
-      if (process.browser) {
+      if (typeof window !== "undefined") {
         if (this.sub) this.sub.removeAllListeners();
         this.sub = this.subscribeTo(provider).on(
           "__change",

--- a/tags/context/src/components/set-context/index.marko
+++ b/tags/context/src/components/set-context/index.marko
@@ -7,7 +7,7 @@ class {
 
   onInput(input) {
     var data = (this.data = {});
-    this.name = input.__from;
+    this.type = input.__from;
 
     for (var key in input) {
       if (key !== "__from" && key !== "renderBody") {

--- a/tags/context/src/helpers.js
+++ b/tags/context/src/helpers.js
@@ -1,5 +1,6 @@
 var CONTEXT_KEY = "__subtree_context__";
 var HAS_BOUND_ASYNC_CONTEXT = "__bound_async_subtree_context__";
+var typeIndex = 0;
 
 exports.pushProvider = function(out, component) {
   if (!out[HAS_BOUND_ASYNC_CONTEXT]) {
@@ -9,15 +10,22 @@ exports.pushProvider = function(out, component) {
 
   var prevContext = out[CONTEXT_KEY];
   var nextContext = (out[CONTEXT_KEY] = Object.create(prevContext || {}));
-  nextContext[component.name] = component;
+  var type = component.type;
+  var typeId = type.___contextTypeId;
+
+  if (!typeId) {
+    typeId = type.___contextTypeId = ++typeIndex;
+  }
+
+  nextContext[typeId] = component;
 
   return function popProvider() {
     out[CONTEXT_KEY] = prevContext;
   };
 };
 
-exports.getProvider = function(out, name) {
-  return out[CONTEXT_KEY][name];
+exports.getProvider = function(out, type) {
+  return out[CONTEXT_KEY][type.___contextTypeId];
 };
 
 function bindSubtreeContextOnBeginAsync(event) {


### PR DESCRIPTION
BREAKING CHANGE: This requires that the context provider is always sent to the browser and rendered in the browser

## Scope

`<context>`

## Description

Currently `<context>` uses the `lasso-client` id (shortened file name) as the id value for the context content in the lookup. This PR updates the context to use the component constructor instead.

## Motivation and Context

The primary benefit of this is that is would fix support for hot swapping out the context provider via mechanisms like jests mock, HMR, etc.
## Checklist:
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
