### PR TITLE
feat(context): support receiving component constructor as from attr

### DIFF
--- a/tags/context/README.md
+++ b/tags/context/README.md
@@ -86,6 +86,14 @@ The `from` attribute here is special and uses the same [discovery method](https:
 
 This method avoids namespace collisions without all of the additional boilerplate needed by solutions in other frameworks.
 
+If for some reason the provider component cannot be discovered through the normal component discovery method, you can `import` the component manually and pass the constructor as the `from` attribute.
+
+```
+import Router from "../../some-strange-path/template.marko";
+
+<context|data| from=Router>
+```
+
 # Example
 
 Lets say we want to have a custom form component with a schema that validates its special form inputs. With forms you likely want to allow developers to insert arbitrary markup and components to fit their design and functionality requirements.

--- a/tags/context/src/components/context/test/fixtures/external-components-from-as-constructor/components/provider.marko
+++ b/tags/context/src/components/context/test/fixtures/external-components-from-as-constructor/components/provider.marko
@@ -1,0 +1,3 @@
+<context data=input.data>
+  <${input}/>
+</context>

--- a/tags/context/src/components/context/test/fixtures/external-components-from-as-constructor/components/receiver.marko
+++ b/tags/context/src/components/context/test/fixtures/external-components-from-as-constructor/components/receiver.marko
@@ -1,0 +1,3 @@
+import Provider from "./provider.marko"
+
+<context|{ data }| from=Provider>[receiver content]${data}</context>

--- a/tags/context/src/components/context/test/fixtures/external-components-from-as-constructor/index.marko
+++ b/tags/context/src/components/context/test/fixtures/external-components-from-as-constructor/index.marko
@@ -1,0 +1,6 @@
+<div data-testid="root">
+  <provider key="provider" data=input.data>
+    [example content]
+    <receiver key="receiver"/>
+  </provider>
+</div>

--- a/tags/context/src/components/context/test/test.browser.js
+++ b/tags/context/src/components/context/test/test.browser.js
@@ -63,6 +63,40 @@ describe("browser", () => {
     });
   });
 
+  describe("rendered in two separate components with from as a constructor", () => {
+    const template = require("./fixtures/external-components-from-as-constructor");
+    let container, rerender, component;
+
+    beforeEach(async () => {
+      ({ container, rerender, getByTestId } = await render(template, {
+        data: "[provided content]"
+      }));
+      component = getComponentForEl(getByTestId("root"));
+    });
+
+    it("renders properly", () => {
+      expect(container).has.text(
+        "[example content] [receiver content][provided content]"
+      );
+    });
+
+    it("updates context on parent rerender", async () => {
+      await rerender({ data: "[provided content updated]" });
+      expect(container).has.text(
+        "[example content] [receiver content][provided content updated]"
+      );
+    });
+
+    it("updates context on receiver rerender", () => {
+      const receiver = component.getComponent("receiver");
+      receiver.forceUpdate();
+      receiver.update();
+      expect(container).has.text(
+        "[example content] [receiver content][provided content]"
+      );
+    });
+  });
+
   describe("rendered with multiple context components", () => {
     const template = require("./fixtures/multiple-context-components");
     let container, rerender, component;

--- a/tags/context/src/components/context/test/test.server.js
+++ b/tags/context/src/components/context/test/test.server.js
@@ -21,6 +21,16 @@ describe("server", () => {
     );
   });
 
+  it("renders in two separate components using from as a constructor", async () => {
+    const template = require("./fixtures/external-components-from-as-constructor");
+    const { container } = await render(template, {
+      data: "[provided content]"
+    });
+    expect(container).has.text(
+      "[example content] [receiver content][provided content]"
+    );
+  });
+
   it("renders across distant components", async () => {
     const template = require("./fixtures/distant-components");
     const { container } = await render(template, {

--- a/tags/context/src/components/context/transformer.js
+++ b/tags/context/src/components/context/transformer.js
@@ -3,32 +3,34 @@ module.exports = function(el, ctx) {
 
   if (el.params.length) {
     // Receive context tag.
-    const fromAttr = el.getAttribute("from");
-    let from = fromAttr && fromAttr.literalValue;
+    let fromValue = el.getAttributeValue("from");
 
-    if (from) {
-      if (from === ".") {
-        from = buildModuleExports(builder);
-      } else {
-        const fromTag = ctx.taglibLookup.getTag(from);
-
-        if (fromTag) {
-          from = ctx.importTemplate(fromTag.template);
-        } else {
-          return ctx.addError(
-            `context receiver could not find context provider matching 'from="${from}"'.`
-          );
-        }
-      }
-    } else {
+    if (!fromValue) {
       return ctx.addError(
         "context 'from' attribute is required and should point to another component."
       );
     }
 
+    if (fromValue.type === "Literal") {
+      const literalValue = fromValue.value;
+      if (literalValue === ".") {
+        fromValue = buildModuleExports(builder);
+      } else {
+        const fromTag = ctx.taglibLookup.getTag(literalValue);
+
+        if (fromTag) {
+          fromValue = ctx.importTemplate(fromTag.template);
+        } else {
+          return ctx.addError(
+            `context receiver could not find context provider matching 'from="${literalValue}"'.`
+          );
+        }
+      }
+    }
+
     const getNode = ctx.createNodeForEl("get-context");
     getNode.params = el.params;
-    getNode.setAttributeValue("__from", from);
+    getNode.setAttributeValue("__from", fromValue);
     getNode.body = el.body;
     el.replaceWith(getNode);
   } else {


### PR DESCRIPTION
## Scope

`<context>`

## Description

Adds support for passing a component constructor as the `from` attribute when receiving context. This makes it possible to receive context from tags which are not discoverable via the normal component discovery.

TLDR:

```marko
import someTag from "./somewhere.marko"

<context|data| from=someTag>
  <!-- ... -->
</context>
```
## Checklist:

- [x] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
