### PR TITLE
fix(context): issue with receiving missing context at the root level

### DIFF
--- a/tags/context/src/components/context/test/fixtures/context-not-provided-same-component/index.marko
+++ b/tags/context/src/components/context/test/fixtures/context-not-provided-same-component/index.marko
@@ -1,0 +1,3 @@
+<context|{ data }| from=".">
+  [receiver content]${data || "[provided nothing]"}
+</context>

--- a/tags/context/src/components/context/test/test.browser.js
+++ b/tags/context/src/components/context/test/test.browser.js
@@ -29,6 +29,18 @@ describe("browser", () => {
     });
   });
 
+  describe("rendered in the same component without any provided context", () => {
+    const template = require("./fixtures/context-not-provided-same-component")
+      .default;
+    let container;
+
+    beforeEach(async () => ({ container } = await render(template, {})));
+
+    it("renders properly", () => {
+      expect(container).has.text("[receiver content][provided nothing]");
+    });
+  });
+
   describe("rendered in two separate components", () => {
     const template = require("./fixtures/external-components").default;
     let container, rerender, component;

--- a/tags/context/src/components/context/test/test.server.js
+++ b/tags/context/src/components/context/test/test.server.js
@@ -11,6 +11,15 @@ describe("server", () => {
     expect(container).has.text("[receiver content][provided content]");
   });
 
+  it("renders in the same component without any provided context", async () => {
+    const template = require("./fixtures/context-not-provided-same-component")
+      .default;
+    const { container } = await render(template, {
+      data: "[provided content]",
+    });
+    expect(container).has.text("[receiver content][provided nothing]");
+  });
+
   it("renders in two separate components", async () => {
     const template = require("./fixtures/external-components").default;
     const { container } = await render(template, {

--- a/tags/context/src/helpers.js
+++ b/tags/context/src/helpers.js
@@ -25,7 +25,7 @@ exports.pushProvider = function (out, component) {
 };
 
 exports.getProvider = function (out, provider) {
-  return out[CONTEXT_KEY][provider.__providerId];
+  return out[CONTEXT_KEY] && out[CONTEXT_KEY][provider.__providerId];
 };
 
 function bindSubtreeContextOnBeginAsync(event) {


### PR DESCRIPTION
## Scope

`<context>`

## Description

FIxes a bug where you would receive an error (instead of the default empty object context param) when accessing a missing context at the root level.

## Checklist:

- [x] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
