### PR TITLE
fix: changed subscribe transformer to have same client/server code

### DIFF
--- a/tags/subscribe/transformer.js
+++ b/tags/subscribe/transformer.js
@@ -30,9 +30,9 @@ function marko5Transform(path, t) {
         )
       );
     }
-
-    path.pushContainer("attributes", t.markoAttribute("__events", eventsArray));
   });
+
+  path.pushContainer("attributes", t.markoAttribute("__events", eventsArray));
 }
 
 function marko4Transform(el, ctx) {

--- a/tags/subscribe/transformer.js
+++ b/tags/subscribe/transformer.js
@@ -6,27 +6,33 @@ module.exports = function (a, b) {
 };
 
 function marko5Transform(path, t) {
-  if (path.hub.file.markoOpts.output === "html") {
-    path.set("attributes", []);
-  } else {
-    const eventsArray = t.arrayExpression([]);
-    path.get("attributes").forEach((attr) => {
-      if (attr.get("arguments").length) {
-        const { type, event } = getTypeAndEvent(attr.get("name").node);
-        if (type) {
-          eventsArray.elements.push(
-            t.stringLiteral(type),
-            t.stringLiteral(event)
-          );
-        }
+  const eventsArray = t.arrayExpression([]);
+  path.get("attributes").forEach((attr) => {
+    if (attr.get("arguments").length) {
+      const { type, event } = getTypeAndEvent(attr.get("name").node);
+      if (type) {
+        eventsArray.elements.push(
+          t.stringLiteral(type),
+          t.stringLiteral(event)
+        );
       }
-
-      path.pushContainer(
-        "attributes",
-        t.markoAttribute("__events", eventsArray)
+    } else if (attr.node.name === "to") {
+      attr.set(
+        "value",
+        t.logicalExpression(
+          "&&",
+          t.binaryExpression(
+            "===",
+            t.unaryExpression("typeof", t.identifier("window")),
+            t.stringLiteral("object")
+          ),
+          attr.node.value
+        )
       );
-    });
-  }
+    }
+
+    path.pushContainer("attributes", t.markoAttribute("__events", eventsArray));
+  });
 }
 
 function marko4Transform(el, ctx) {


### PR DESCRIPTION
## Scope
There is a cache issue where transformers would run compile on server and then not compile on browser again.
So fixed subscribe to do a check if it's running in the browser in order to get the `to` attribute.

## Checklist:

- [X] I have updated/added documentation affected by my changes.
- [X] I have added tests to cover my changes.
