### PR TITLE
Fix match-media example bug

### DIFF
--- a/tags/match-media/README.md
+++ b/tags/match-media/README.md
@@ -36,7 +36,6 @@ npm install @marko-tags/match-media
   tablet="(min-width: 768px) and (max-width: 1024px)"
   desktop="(min-width: 1025px)"
 >
-
   <if(mobile)>
     <!-- Mobile version -->
   </if>
@@ -49,7 +48,6 @@ npm install @marko-tags/match-media
   <else>
     <!-- Handle server side render (no media queries match) -->
   </else>
-
 </match-media>
 ```
 

--- a/tags/match-media/README.md
+++ b/tags/match-media/README.md
@@ -38,6 +38,7 @@ npm install @marko-tags/match-media
 >
   <if(mobile)>
     <!-- Mobile version -->
+  </if>
   <else-if(tablet)>
     <!-- Tablet version -->
   </else-if>

--- a/tags/match-media/README.md
+++ b/tags/match-media/README.md
@@ -39,6 +39,7 @@ npm install @marko-tags/match-media
 
   <if(mobile)>
     <!-- Mobile version -->
+  </if>
   <else-if(tablet)>
     <!-- Tablet version -->
   </else-if>

--- a/tags/match-media/README.md
+++ b/tags/match-media/README.md
@@ -38,7 +38,6 @@ npm install @marko-tags/match-media
 >
   <if(mobile)>
     <!-- Mobile version -->
-  </if>
   <else-if(tablet)>
     <!-- Tablet version -->
   </else-if>


### PR DESCRIPTION
## Scope

match-media

## Description

The example code in match-media readme has a bug since its missing a closing if tag

## Motivation and Context

I was reading the docs and tried this example and ran into an error.

## Checklist:

- [x] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
