### PR TITLE
Add closing </if> tag in example

### DIFF
--- a/tags/match-media/README.md
+++ b/tags/match-media/README.md
@@ -39,6 +39,7 @@ npm install @marko-tags/match-media
 
   <if(mobile)>
     <!-- Mobile version -->
+  </if>
   <else-if(tablet)>
     <!-- Tablet version -->
   </else-if>


### PR DESCRIPTION
## Scope

match-media

## Description

The example code in match-media README has a bug since its missing a closing if tag

## Motivation and Context

I was reading the docs and tried this example and ran into an error.

