### PR TITLE
fix(portal): vite support

### DIFF
--- a/tags/portal/index.marko
+++ b/tags/portal/index.marko
@@ -1,4 +1,4 @@
-import targetTemplate from './target'
+import targetTemplate from './target.marko'
 
 class {
     onRender(out) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Scope

`<portal>`

## Description
Uses a the file extension on a Marko template import. Vite with it's default/recommended config will not resolve the Marko file without the extension.
Resolves #68

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
