### PR TITLE
fix: don't run match-media if it doesn't exist

### DIFF
--- a/tags/match-media/index.marko
+++ b/tags/match-media/index.marko
@@ -8,7 +8,7 @@ class {
   }
 
   onRender() {
-    if (typeof window === "undefined") return;
+    if (typeof window === "undefined" || !window.matchMedia) return;
 
     var component = this;
     var matches = this.matches;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Scope

<!-- Which tags does this PR affect? -->
match-media

## Description

<!--- Describe your changes in detail.  Include the package name if applicable. -->

Adds an additional guard to check if `window.matchMedia` exists

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

Prior version used `process.browser`. The `window` check will return true in environments that have `window` but aren't the browser (JSDOM, probably Deno)

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
