### PR TITLE
fix(subscribe): TypeScript limitation

### DIFF
--- a/tags/subscribe/index.d.marko
+++ b/tags/subscribe/index.d.marko
@@ -1,4 +1,1 @@
-export interface Input {
-  to: unknown,
-  [event: `on${string}`]: (...args: any[]) => void
-}
+export type Input = any;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Scope

- `<subscribe>` tag (TS only)

## Description

- Some users of `<subscribe>` tag were seeing a "Type instantiation is excessively deep and possibly infinite." error, I couldn't find any solutions besides switching to `any`.
